### PR TITLE
Only add StockOnOrderConfig if not exist

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0</version>
+    <version>1.1</version>
     <author>
         <name>Etienne Perriere</name>
         <email>eperriere@openstudio.fr</email>


### PR DESCRIPTION
If a payment module (or a status) is added after this module, you have to :
- deactivate the module
- manually remove the SQL table content.
- activate the module
- reconfigure all (previous and new)

This PR check on post activation if module/status already exist and add only if needed